### PR TITLE
fix Scala 2.13 deprecation warning

### DIFF
--- a/src/edu/uwm/cs/scalabison/BisonScanner.scala
+++ b/src/edu/uwm/cs/scalabison/BisonScanner.scala
@@ -178,7 +178,7 @@ class BisonScanner(input : Iterator[Char])
   private var savedState : State = null;
 
   /*override*/ def hasNext : Boolean = state != null && state.hasNext;
-  /*override*/ def next : BisonTokens.YYToken = state.next;
+  /*override*/ def next() : BisonTokens.YYToken = state.next;
 
   class InitialState extends State {
     override def hasNext : Boolean = {


### PR DESCRIPTION
depreciation warning fixed

```
amir@amir-desktop:~/workspace/scala-bison$ make compile
mkdir -p bin
(cd src; scalac -d ../bin edu/uwm/cs/util/*.scala edu/uwm/cs/scalabison/*.scala)
edu/uwm/cs/scalabison/BisonScanner.scala:181: warning: method without a parameter list overrides method next in trait Iterator defined with a single empty parameter list [quickfixable]
  /*override*/ def next : BisonTokens.YYToken = state.next;
```